### PR TITLE
docker: update to jammy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:jammy-1.0.3
 
 
 WORKDIR /opt/app


### PR DESCRIPTION
Update docker base image to jammy. Makes supporting different architectures possible. 